### PR TITLE
Add possibility for manager to see just his restaurants

### DIFF
--- a/administrator/admin.py
+++ b/administrator/admin.py
@@ -66,6 +66,7 @@ class UserChangeForm(forms.ModelForm):
         user = super(UserChangeForm, self).save(commit=False)
         user.set_is_active(user.status)
         user.set_is_staff(user.role)
+        user.set_permissions(user.role)
         if commit:
             user.save()
         return user
@@ -84,6 +85,15 @@ class UserAdmin(Admin):
 
     """Represent a model in the admin interface."""
 
+    """def queryset(self, request):
+        qs = super(UserAdmin, self).queryset(request)
+
+        # If super-user, show all comments
+        if request.user.role == Role.objects.get(id=1):
+            return qs
+
+        return qs.filter(added_by=request.user)"""
+
     form = UserChangeForm
     add_form = RegistrationForm
 
@@ -99,6 +109,7 @@ class UserAdmin(Admin):
         (_('Status'), {'fields': ('status',)}),
         (_('Permissions'), {'fields': ('role',)}),
     )
+
 
     # add_fieldsets is not a standard ModelAdmin attribute. UserAdmin
     # overrides get_fieldsets to use this attribute when creating a user.
@@ -156,6 +167,17 @@ class RestaurantForm(forms.ModelForm):
 class RestaurantAdmin(admin.ModelAdmin):
 
     """Custom display in restaurant's list."""
+
+    def get_queryset(self, request):
+        """ Represent the objects.
+
+        Return a QuerySet of all model instances that can be edited
+        by the admin site.
+        """
+        qs = super(RestaurantAdmin, self).get_queryset(request)
+        if request.user.role == Role.objects.get(id=1):
+            return qs
+        return qs.filter(manager=request.user.id)
 
     form = RestaurantForm
 

--- a/administrator/admin.py
+++ b/administrator/admin.py
@@ -102,7 +102,6 @@ class UserAdmin(Admin):
         (_('Permissions'), {'fields': ('role',)}),
     )
 
-
     # add_fieldsets is not a standard ModelAdmin attribute. UserAdmin
     # overrides get_fieldsets to use this attribute when creating a user.
     add_fieldsets = (

--- a/administrator/admin.py
+++ b/administrator/admin.py
@@ -40,6 +40,7 @@ class RegistrationForm(UserCreationForm):
         user.email = self.cleaned_data['email']
         user.role = self.cleaned_data['role']
         user.set_is_staff(user.role)
+        user.set_permissions(user.role)
         if commit:
             user.save()
         return user
@@ -84,15 +85,6 @@ delete_selected_users.short_description = "Delete selested users"
 class UserAdmin(Admin):
 
     """Represent a model in the admin interface."""
-
-    """def queryset(self, request):
-        qs = super(UserAdmin, self).queryset(request)
-
-        # If super-user, show all comments
-        if request.user.role == Role.objects.get(id=1):
-            return qs
-
-        return qs.filter(added_by=request.user)"""
 
     form = UserChangeForm
     add_form = RegistrationForm

--- a/administrator/models/role.py
+++ b/administrator/models/role.py
@@ -9,9 +9,5 @@ class Role(Group):
     """
 
     class Meta:
-        db_table = 'roles'
-        ordering = ['name']
         proxy = True
         verbose_name = _('role')
-        verbose_name_plural = _('roles')
-

--- a/administrator/models/user.py
+++ b/administrator/models/user.py
@@ -5,7 +5,6 @@ Contain a model class for users and a manager for this model.
 :copyright: (c) 2017 by Ol'ha Leskovs'ka
 """
 
-from django.contrib import messages
 from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import PermissionsMixin
@@ -37,6 +36,7 @@ class UserManager(BaseUserManager):
         user = self.model(email=email, name=name, **extra_fields)
         user.set_password(password)
         user.save(using=self._db)
+        user.set_permissions(extra_fields.get('role'))
         return user
 
     def create_user(self, email, name, password, **extra_fields):
@@ -203,3 +203,12 @@ class User(AbstractBaseUser, PermissionsMixin):
             return False
         else:
             return True
+
+    def set_permissions(self, role):
+        """Set user_permissions according to user's role.
+
+        Argument:
+        role - user's role
+        """
+        for perm in role.permissions.all():
+            self.user_permissions.add(perm)

--- a/fixtures/roles.json
+++ b/fixtures/roles.json
@@ -182,7 +182,6 @@
     "fields": {
         "name": "User",
         "permissions": [
-
             [
                 "read_dishcategory",
                 "administrator",

--- a/fixtures/roles.json
+++ b/fixtures/roles.json
@@ -182,6 +182,7 @@
     "fields": {
         "name": "User",
         "permissions": [
+
             [
                 "read_dishcategory",
                 "administrator",
@@ -216,6 +217,21 @@
                 "user"
             ],
             [
+                "add_restaurant",
+                "restaurant",
+                "restaurant"
+            ],
+            [
+                "change_restaurant",
+                "restaurant",
+                "restaurant"
+            ],
+            [
+                "delete_restaurant",
+                "restaurant",
+                "restaurant"
+            ],
+            [
                 "read_restaurant",
                 "restaurant",
                 "restaurant"
@@ -224,6 +240,11 @@
                 "read_restaurant",
                 "restaurant",
                 "restauranttype"
+            ],
+            [
+                "add_user",
+                "administrator",
+                "user"
             ]
         ]
     }

--- a/restaurant/models/restaurant.py
+++ b/restaurant/models/restaurant.py
@@ -83,4 +83,6 @@ class Restaurant(models.Model):
         else:
             role = Role.objects.get(id=3)
         user.role = role
+        user.set_permissions(role)
+        user.set_is_staff(role)
         user.save()


### PR DESCRIPTION
Manager can log into admin site and work with his/her restaurants. 

I think it will help you to do your tasks.

There is a bug (when you change a manager the old manager's role doesn't change). I'll fix it in the evening. 

Don't forget to update roles permissions in the database (python manage.py loaddata fixtures/roles.json)
